### PR TITLE
pm4py 2.7.11.8 :snowflake:

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,10 +42,16 @@ requirements:
 test:
   imports:
     - pm4py
-  commands:
-    - pip check
   requires:
     - pip
+    - pytest
+  source_files:
+    - tests
+  commands:
+    - pip check
+    - cd tests
+    # as suggested in tests/README.txt
+    - python execute_tests.py
 
 about:
   home: https://pm4py.fit.fraunhofer.de

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,64 @@
+{% set name = "pm4py" %}
+{% set version = "2.7.11.8" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pm4py-{{ version }}.tar.gz
+  sha256: f655de1c9745546b0f4366c0fdfc635ca6bcdc75381a0701401453c546744a63
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+
+requirements:
+  host:
+    - python
+    - pip
+    - setuptools
+    - wheel
+  run:
+    - python
+    - numpy <2
+    - pandas
+    - deprecation
+    - networkx
+    - python-graphviz
+    - wheel
+    - setuptools
+    - intervaltree
+    - lxml
+    - matplotlib-base
+    - pydotplus
+    - pytz
+    - scipy
+    - tqdm
+    - cvxopt  # [py<313]
+
+test:
+  imports:
+    - pm4py
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://pm4py.fit.fraunhofer.de
+  license: GPL-3.0
+  license_family: GPL
+  license_file: LICENSE
+  summary: Process mining for Python
+  description: |
+    pm4py is a python library that supports (state-of-the-art) process mining
+    algorithms in python. It is open source (licensed under GPL) and intended
+    to be used in both academia and industry projects. pm4py is a product of
+    the Fraunhofer Institute for Applied Information Technology.
+  doc_url: https://pm4py.fit.fraunhofer.de
+  dev_url: https://github.com/pm4py/pm4py-source
+
+extra:
+  recipe-maintainers:
+    - lorepirri

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,8 +28,6 @@ requirements:
     - deprecation
     - networkx
     - python-graphviz
-    - wheel
-    - setuptools
     - intervaltree
     - lxml
     - matplotlib-base
@@ -55,7 +53,7 @@ test:
 
 about:
   home: https://pm4py.fit.fraunhofer.de
-  license: GPL-3.0
+  license: GPL-3.0-only
   license_family: GPL
   license_file: LICENSE
   summary: Process mining for Python
@@ -65,7 +63,7 @@ about:
     to be used in both academia and industry projects. pm4py is a product of
     the Fraunhofer Institute for Applied Information Technology.
   doc_url: https://pm4py.fit.fraunhofer.de
-  dev_url: https://github.com/pm4py/pm4py-source
+  dev_url: https://github.com/pm4py/pm4py-core
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,8 @@ source:
 
 build:
   number: 0
+  # cvxopt not available for s390x and win
+  skip: true  # [s390x or win]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:


### PR DESCRIPTION
pm4py 2.7.11.8 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-4246]
- dev_url: https://github.com/pm4py/pm4py-core/tree/2.7.11.8
- pypi: https://pypi.org/project/pm4py/2.7.11.8
- pypi inspector: https://inspector.pypi.io/project/pm4py/2.7.11.8



### Explanation of changes:

- new recipe
- upstream tests
- skip `win` and `s390x` because `cvxopt` is missing
- linter complains about `invalid_url` because their certificate has expired


[PKG-4246]: https://anaconda.atlassian.net/browse/PKG-4246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ